### PR TITLE
Add missing dependency to stream.deferred

### DIFF
--- a/src/manifold/stream/deferred.clj
+++ b/src/manifold/stream/deferred.clj
@@ -1,7 +1,8 @@
 (ns manifold.stream.deferred
   (:require
     [manifold.deferred :as d]
-    [manifold.stream.core :as s])
+    [manifold.stream.core :as s]
+    manifold.stream.graph)
   (:import
     [manifold.deferred
      IDeferred]


### PR DESCRIPTION
This namespace cannot be `require`d without adding this dependency