### PR TITLE
Allow function passed to `time/in` to return a deferred value

### DIFF
--- a/src/manifold/time.clj
+++ b/src/manifold/time.clj
@@ -125,7 +125,7 @@
 ;;;
 
 (in-ns 'manifold.deferred)
-(clojure.core/declare success! error! deferred realized? chain)
+(clojure.core/declare success! error! deferred realized? chain connect)
 (in-ns 'manifold.time)
 
 ;;;
@@ -258,7 +258,7 @@
           f (fn []
               (when-not (manifold.deferred/realized? d)
                 (try
-                  (manifold.deferred/success! d (f))
+                  (manifold.deferred/connect (f) d)
                   (catch Throwable e
                     (manifold.deferred/error! d e)))))
           cancel-fn (.in *clock* interval f)]

--- a/src/manifold/time.clj
+++ b/src/manifold/time.clj
@@ -251,8 +251,9 @@
 
 (defn in
   "Schedules no-arg function `f` to be invoked in `interval` milliseconds.  Returns a deferred
-     representing the returned value of the function. If the returned deferred is completed before
-     the interval has passed, the timeout function will be cancelled."
+  representing the returned value of the function. If the returned deferred is completed before
+  the interval has passed, the timeout function will be cancelled. If `f` returns a deferred,
+  then it will be "
     [^double interval f]
     (let [d (manifold.deferred/deferred)
           f (fn []
@@ -278,7 +279,7 @@
    (.every *clock* initial-delay period f)))
 
 (defn at
-  "Schedules no-arg function  `f` to be invoked at `timestamp`, which is the milliseconds
-   since the epoch.  Returns a deferred representing the returned value of the function."
+  "Schedules no-arg function `f` to be invoked at `timestamp`, which is the milliseconds
+  since the epoch.  Returns a deferred representing the returned value of the function."
   [timestamp f]
   (in (max 0 (- timestamp (System/currentTimeMillis))) f))

--- a/src/manifold/time.clj
+++ b/src/manifold/time.clj
@@ -251,9 +251,9 @@
 
 (defn in
   "Schedules no-arg function `f` to be invoked in `interval` milliseconds.  Returns a deferred
-  representing the returned value of the function. If the returned deferred is completed before
-  the interval has passed, the timeout function will be cancelled. If `f` returns a deferred,
-  then it will be "
+  representing the returned value of the function (or deferred value if `f` itself returns a 
+  deferred). If the returned deferred is completed before the interval has passed, the timeout 
+  function will be cancelled."
     [^double interval f]
     (let [d (manifold.deferred/deferred)
           f (fn []
@@ -280,6 +280,7 @@
 
 (defn at
   "Schedules no-arg function `f` to be invoked at `timestamp`, which is the milliseconds
-  since the epoch.  Returns a deferred representing the returned value of the function."
+  since the epoch.  Returns a deferred representing the returned value of the function
+  (or deferred value if `f` itself returns a deferred)."
   [timestamp f]
   (in (max 0 (- timestamp (System/currentTimeMillis))) f))

--- a/test/manifold/time_test.clj
+++ b/test/manifold/time_test.clj
@@ -6,9 +6,25 @@
     [manifold.time :as t]))
 
 (deftest test-in
-  (let [n (atom 0)]
-    @(t/in 1 #(swap! n inc))
-    (is (= 1 @n))))
+  (testing "side-effecting function"
+    (let [n (atom 0)]
+     @(t/in 1 #(swap! n inc))
+     (is (= 1 @n))))
+
+  (testing "function throws exception"
+    (is (thrown?
+          Exception
+          @(t/in 1 (fn [] (throw (Exception. "Boom")))))))
+
+  (testing "delayed function returns deferred"
+    (let [d (d/deferred)]
+      (d/success! d 1)
+      (is (= 1 @(t/in 1 (fn [] d))))))
+
+  (testing "delayed function returns failed deferred"
+    (let [d (d/deferred)]
+      (d/error! d (Exception. "BOOM"))
+      (is (thrown? Exception @(t/in 1 (fn [] d)))))))
 
 (deftest test-every
   (let [n (atom 0)


### PR DESCRIPTION
In the current implementation of `time/in`, if the passed function returns a deferred value then after everything is done it results in a deferred wrapping a deferred. This changes it so the deferred returned by the passed function is connected through.