### PR TITLE
Add deps.edn to satisfy Deps CLI manifest requirement for :git/url dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:deps {org.clojure/tools.logging {:mvn/version "0.3.1" :exclusions [org.clojure/clojure]}
+        io.aleph/dirigiste        {:mvn/version "0.1.6-alpha1"}
+        riddley/riddley           {:mvn/version "0.1.15"}}}


### PR DESCRIPTION
Allows adding deps to use specific commits on Github not yet on Clojars that fix [specific issues](https://github.com/aleph-io/manifold/issues/187), e.g.:

```
{:deps {aleph/manifold {:git/url    "https://github.com/aleph-io/manifold.git"
                        :sha        "aec26d90c4c0eeb71394c416821d0c5fe8bb1fc9"}}}
```

It's either this, or a `pom.xml` file as manifest. Annoyingly, it means you have to maintain two lists of deps. I've been gradually moving most of my projects away from project.clj toward deps.edn.