### PR TITLE
Fix for pending takes not cleaned up when they timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: clojure
-script: lein do clean, jammin 180 test
-jdk:
-  - openjdk7
-  - openjdk8
-  - openjdk9
-  - openjdk11

--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -282,7 +282,7 @@
    Guaranteed to be non-blocking.
 
    Special `timeout-val` and `default-val` values may be specified, if it is
-   important to differentiate between actual `nil` values and failures."
+   important to differentiate between actual `nil` values and timeouts/failures."
   {:inline (fn
              ([source timeout]
                `(.take ~(with-meta source {:tag "manifold.stream.core.IEventSource"}) nil false ~timeout nil))

--- a/src/manifold/stream/default.clj
+++ b/src/manifold/stream/default.clj
@@ -233,7 +233,7 @@
         (do
           (log/warn (IllegalStateException.) "excessive pending takes (> 16384), closing stream")
           (s/close! this)
-          (d/success-deferred false executor))
+          (d/success-deferred default-val executor))
 
         (instance? Consumption result)
         (let [^Consumption result result]

--- a/src/manifold/stream/default.clj
+++ b/src/manifold/stream/default.clj
@@ -48,13 +48,14 @@
 (defn- cleanup-expired-deferreds
   "Removes all realized deferreds (presumably from timing out)."
   [^LinkedList l]
-  (when-not (.isEmpty l)
-    (let [iter (.iterator l)]
-      (loop [c (.next iter)]
-        (when (-> c :deferred d/realized?)
-          (.remove iter))
-        (when (.hasNext iter)
-          (recur (.next iter)))))))
+  (locking l
+    (when-not (.isEmpty l)
+      (let [iter (.iterator l)]
+        (loop [c (.next iter)]
+          (when (-> c :deferred d/realized?)
+            (.remove iter))
+          (when (.hasNext iter)
+            (recur (.next iter))))))))
 
 (s/def-sink+source Stream
   [^boolean permanent?


### PR DESCRIPTION
## About
Fixes #194 by cleaning the pending put/take lists every X calls

## Changes

- Periodically cleans up pending takes/puts, and removes any that have been realized (presumably due to timeout)
- Fixes value returned when the number of takes exceeds the limit, to match the documentation
- Adds tests
- Defines vars for the put/take limits and how often to check, in case anybody wants to tune those

#### Internal details
Producer and Consumer were changed from types to records. We need to access the `deferred` field in both, but that incurs a reflection penalty in the cleanup fn. The choice was between making a duplicate cleanup fn, adding a protocol to access `.-deferred` and hinting with that, or switching to records and using keyword access.

I'd rather not make a duplicate fn that's 99% the same, and a macro feels like a bit much just for this. I checked with Criterium, and keyword access is only 25% slower (ditto for a new protocol) but still just a few nanoseconds, so this seems acceptable.