### PR TITLE
Force bindings inside `let-flow` to be unique

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1290,6 +1290,7 @@
   (let [[_ bindings & body] (walk/macroexpand-all `(let ~bindings ~@body))
         locals              (keys (compiler/locals))
         vars                (->> bindings (partition 2) (map first))
+        _                   (assert (apply distinct? vars) "Let binding vars must be unique.")
         marker              (gensym)
         vars'               (->> vars (concat locals) (map #(vary-meta % assoc marker true)))
         gensyms             (repeatedly (count vars') gensym)


### PR DESCRIPTION
Without this, the following code can randomly pick "cat" or "dog" (though "dog" is far more common, making this bug hard to detect or reproduce).

```clj
@(let-flow [a "cat"
            a "dog"]
   a)
```

Note: There's a likelyhood that users updating to this code will need to update their code base due to it failing to compile. I (Ryan Smith) find this acceptable as the code is already broken, even if the user hasn't realized it yet.