### PR TITLE
Use `bound-fn` in `let-flow`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 ### 0.2.0-SNAPSHOT
 
-Contributions by Matthew Davidson
+Contributions by Matthew Davidson, Ryan Smith
 
-* Modernized indentation to match current Clojure styles and fixed misalignments
+* Switch to `bound-fn` in `let-flow` to fix bug where dynamic vars were incorrect for other threads 
+* Modernized indentation to match current Clojure styles and fix misalignments
 
 ### 0.1.9
 

--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1330,14 +1330,14 @@
                            [gensym val])
                          [gensym
                           `(~chain-fn (~zip-fn ~@deps)
-                            (fn [[~@(map gensym->var deps)]]
+                            (bound-fn [[~@(map gensym->var deps)]]
                               ~val))])))
                    (range)
                    vars'
                    vals'
                    gensyms)]
            (~chain-fn (onto (~zip-fn ~@body-dep?) executor#)
-            (fn [[~@(map gensym->var body-dep?)]]
+            (bound-fn [[~@(map gensym->var body-dep?)]]
               ~@body)))))))
 
 (defmacro let-flow


### PR DESCRIPTION
`bound-fn` preserves bindings of dynamic variables, even if the function ends up
being executed on a different thread.

I've made sure to test that without this change, the test I've added to detect
dynamic variables across executor threads actually does still fail.