### PR TITLE
Update docstring for `manifold.deferred/alt`.

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1130,7 +1130,7 @@
     @(alt (future (Thread/sleep 1) 1)
           (future (Thread/sleep 1) 2)) => 1 or 2 depending on the thread scheduling
 
-  Values appearing earlier in the input are preferred."
+  The values are not tried in-order, but iterated over with an initial random shuffle."
   [& vals]
   (->> vals
        (map #(or (->deferred % nil) %))


### PR DESCRIPTION
The ordering of values was changed to a shuffle in commit 92c742b970e031418e5e91688441ad3a3875ca7c, to match the behaviour of `clojure.core.async/alts!`, but the docstring was not updated.

Fixes #205.