### PR TITLE
Fully reference `java.util.concurrent.Executor`

### DIFF
--- a/src/manifold/go_off.clj
+++ b/src/manifold/go_off.clj
@@ -7,8 +7,7 @@
             [clojure.core.async.impl
              [ioc-macros :as ioc]]
             [manifold.stream :as s])
-  (:import (java.util.concurrent Executor)
-           (manifold.stream.core IEventSource)))
+  (:import (manifold.stream.core IEventSource)))
 
 (defn return-deferred [state value]
   (let [d (ioc/aget-object state ioc/USER-START-IDX)]
@@ -75,7 +74,7 @@
 (defmacro go-off-executor
   "Implementation of go-off that allows specifying executor. See docstring of go-off for usage."
   [executor & body]
-  (let [executor     (vary-meta executor assoc :tag 'Executor)
+  (let [executor     (vary-meta executor assoc :tag 'java.util.concurrent.Executor)
         crossing-env (zipmap (keys &env) (repeatedly gensym))]
     `(let [d#                 (d/deferred)
            captured-bindings# (clojure.lang.Var/getThreadBindingFrame)]

--- a/test/manifold/go_off_test.clj
+++ b/test/manifold/go_off_test.clj
@@ -6,7 +6,7 @@
             [manifold.executor :as ex]
             [clojure.string :as str]
             [manifold.stream :as s])
-  (:import (java.util.concurrent TimeoutException Executor)))
+  (:import (java.util.concurrent TimeoutException)))
 
 (deftest async-test
   (testing "values are returned correctly"


### PR DESCRIPTION
In a macro, we need to make sure we're fully referencing
java imports.