### PR TITLE
Add new-thread-fn parameter to manifold.executor/thread-factory

### DIFF
--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -37,10 +37,8 @@
 
   It represents the default implementation on `thread-factory` when the
   `new-thread-fn` argument is no passed."
-  ([group target name]
-   (Thread. group target name))
-  ([group target name stack-size]
-   (Thread. group target name stack-size)))
+  [group target name stack-size]
+  (Thread. group target name stack-size))
 
 (defn ^ThreadFactory thread-factory
   "Returns a `java.util.concurrent.ThreadFactory`.
@@ -50,7 +48,7 @@
    | `executor-promise` | a promise eventually containing a `java.util.concurrent.Executor` that will be stored on `manifold.executor/executor-thread-local`. |
    | `stack-size` | the desired stack size for the new thread, or nil/zero to indicate that this parameter is to be ignored. |
    | `daemon?` | marks the created threads as either daemon or user threads. The Java Virtual Machine exits when the only threads running are all daemon threads. |
-   | `new-thread-fn` | a three/four arguments function which returns an implementation of `java.lang.Thread` when called. |"
+   | `new-thread-fn` | a four arguments function which returns an implementation of `java.lang.Thread` when called. |"
   ([name-generator executor-promise]
    (thread-factory name-generator executor-promise nil true nil))
   ([name-generator executor-promise stack-size]
@@ -66,9 +64,7 @@
                f           #(do
                               (.set executor-thread-local @executor-promise)
                               (.run ^Runnable runnable))
-               thread      (if stack-size
-                             ^Thread (new-thread nil f name stack-size)
-                             ^Thread (new-thread nil f name))]
+               thread      ^Thread (new-thread nil f name (or stack-size 0))]
            (doto thread
              (.setDaemon daemon?)
              (.setContextClassLoader curr-loader))))))))

--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -33,6 +33,10 @@
          (.set executor-thread-local executor#)))))
 
 (defn- ^Thread new-thread
+  "Create a new `java.lang.Thread`.
+
+  It represents the default implementation on `thread-factory` when the
+  `new-thread-fn` argument is no passed."
   ([group target name]
    (Thread. group target name))
   ([group target name stack-size]

--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -33,10 +33,14 @@
          (.set executor-thread-local executor#)))))
 
 (defn- ^Thread new-thread
-  "Create a new `java.lang.Thread`.
+  "Creates a new `java.lang.Thread`.
 
   It represents the default implementation on `thread-factory` when the
-  `new-thread-fn` argument is not passed."
+  `new-thread-fn` argument is not passed.
+
+  Some libraries require a different implementation of a `java.lang.Thread`.
+  That's the case of Netty which behaves differently when
+  running on a `io.netty.util.concurrent.FastThreadLocalThread`."
   [group target name stack-size]
   (Thread. group target name stack-size))
 

--- a/src/manifold/executor.clj
+++ b/src/manifold/executor.clj
@@ -36,7 +36,7 @@
   "Create a new `java.lang.Thread`.
 
   It represents the default implementation on `thread-factory` when the
-  `new-thread-fn` argument is no passed."
+  `new-thread-fn` argument is not passed."
   [group target name stack-size]
   (Thread. group target name stack-size))
 

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -32,11 +32,39 @@
   (let [num-threads      (atom 0)
         in-thread-loader (promise)
         tf               (e/thread-factory
-                           #(str "my-loader-prefix-" (swap! num-threads inc))
-                           (deliver (promise) nil))
+                          #(str "my-loader-prefix-" (swap! num-threads inc))
+                          (deliver (promise) nil))
         executor         (Executors/newFixedThreadPool 1 ^ThreadFactory tf)]
     (.execute ^ExecutorService executor
               (fn []
                 (let [l (clojure.lang.RT/baseLoader)]
                   (deliver in-thread-loader l))))
     (is (instance? clojure.lang.DynamicClassLoader @in-thread-loader))))
+
+(defn- ^ThreadFactory thread-factory
+  ([] (thread-factory nil))
+  ([new-thread-fn] (thread-factory new-thread-fn nil))
+  ([new-thread-fn stack-size]
+   (let [num-threads (atom 0)
+         tf (e/thread-factory
+             #(str "my-pool-prefix" (swap! num-threads inc))
+             (deliver (promise) nil)
+             stack-size
+             false
+             new-thread-fn)]
+     tf)))
+
+(deftest test-thread-factory
+  (let [tf (thread-factory)]
+    (.newThread tf (constantly nil)))
+  (let [tf (thread-factory
+            (fn [group target _]
+              (proxy [Thread] [group target "custom-name"])))
+        thread (.newThread tf (constantly nil))]
+    (is (= "custom-name" (.getName thread))))
+  (let [tf (thread-factory
+            (fn [group target _ stack-size]
+              (proxy [Thread] [group target "custom-name" stack-size]))
+            500)
+        thread (.newThread tf (constantly nil))]
+    (is (= "custom-name" (.getName thread)))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -58,8 +58,8 @@
   (let [tf (thread-factory)]
     (.newThread tf (constantly nil)))
   (let [tf (thread-factory
-            (fn [group target _]
-              (proxy [Thread] [group target "custom-name"])))
+            (fn [group target _ stack-size]
+              (proxy [Thread] [group target "custom-name" stack-size])))
         thread (.newThread tf (constantly nil))]
     (is (= "custom-name" (.getName thread))))
   (let [tf (thread-factory

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -56,7 +56,7 @@
 
 (deftest test-thread-factory
   (let [tf (thread-factory)]
-    (.newThread tf (constantly nil)))
+    (is (.newThread tf (constantly nil))))
   (let [tf (thread-factory
             (fn [group target _ stack-size]
               (proxy [Thread] [group target "custom-name" stack-size])))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -59,12 +59,12 @@
     (is (.newThread tf (constantly nil))))
   (let [tf (thread-factory
             (fn [group target _ stack-size]
-              (proxy [Thread] [group target "custom-name" stack-size])))
+              (Thread. group target "custom-name" stack-size)))
         thread (.newThread tf (constantly nil))]
     (is (= "custom-name" (.getName thread))))
   (let [tf (thread-factory
             (fn [group target _ stack-size]
-              (proxy [Thread] [group target "custom-name" stack-size]))
+              (Thread. group target "custom-name" stack-size))
             500)
         thread (.newThread tf (constantly nil))]
     (is (= "custom-name" (.getName thread)))))

--- a/test/manifold/executor_test.clj
+++ b/test/manifold/executor_test.clj
@@ -32,8 +32,8 @@
   (let [num-threads      (atom 0)
         in-thread-loader (promise)
         tf               (e/thread-factory
-                          #(str "my-loader-prefix-" (swap! num-threads inc))
-                          (deliver (promise) nil))
+                           #(str "my-loader-prefix-" (swap! num-threads inc))
+                           (deliver (promise) nil))
         executor         (Executors/newFixedThreadPool 1 ^ThreadFactory tf)]
     (.execute ^ExecutorService executor
               (fn []


### PR DESCRIPTION
## Description

This adds a parameter called `thread-class` to `manifold.executor/thread-factory` to be able to 
pass custom implementation of a `java.lang.Thread`. 
This feature will be particularly useful for Aleph to be able to construct thread-pools with
`io.netty.util.concurrent.FastThreadLocalThread` as mentioned on the following PR https://github.com/clj-commons/aleph/pull/595.

I'm unsure about the proposed implementation and I'm wondering whether including
this complexity on `manifold.executor` is really worth.

Open to comments!