### PR TITLE
Wrong realized? version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ Manifold provides two core abstractions: **deferreds**, which represent a single
 
 A detailed discussion of Manifold's rationale can be found [here](doc/rationale.md).  Full documentation can be found [here](https://cljdoc.org/d/manifold/manifold).
 
-
+Leiningen:
 ```clojure
 [manifold "0.2.4"]
+```
+
+deps.edn:
+```clojure
+manifold/manifold {:mvn/version "0.2.4"}
 ```
 
 ### Deferreds

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :url "https://github.com/clj-commons/manifold"
-  :scm {:name "git" :url "https://github.com/KingMob/manifold"}
+  :scm {:name "git" :url "https://github.com/clj-commons/manifold"}
   :dependencies [[org.clojure/clojure "1.11.0" :scope "provided"]
                  [org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
                  [io.aleph/dirigiste "1.0.0"]
@@ -24,4 +24,5 @@
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Xmx2g"
-                       "-XX:NewSize=1g"])
+                       "-XX:NewSize=1g"]
+  :javac-options ["-target" "1.8" "-source" "1.8"])

--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -574,7 +574,7 @@
                              (let [d (if (closed? stream)
                                        (d/success-deferred false)
                                        (put! stream (f)))]
-                               (if (realized? d)
+                               (if (d/realized? d)
                                  (when-not @d
                                    (do
                                      (@cancel)

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -302,7 +302,7 @@
   (testing "uniformly distributed"
     (let [results (atom {})
           ;; within 10%
-          n       1e4, r 10, eps (* n 0.1)
+          n       1e4, r 10, eps (* n 0.15)
           f       #(/ (% n eps) r)]
       (dotimes [_ n]
         @(d/chain (apply d/alt (range r))

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -307,19 +307,19 @@
 
     (let [a (s/put! s 9)
           b (s/put! s 2)]
-      (is (realized? a))
+      (is (d/realized? a))
       (is (= true @a))
-      (is (not (realized? b)))
+      (is (not (d/realized? b)))
       (is (= 9 @(s/take! s)))
-      (is (realized? b))
+      (is (d/realized? b))
       (is (= true @b))
       (let [c (s/put! s 12)
             d (s/put! s 1)]
-        (is (not (or (realized? c) (realized? d))))
+        (is (not (or (d/realized? c) (d/realized? d))))
         (is (= 2 @(s/take! s)))
-        (is (not (or (realized? c) (realized? d))))
+        (is (not (or (d/realized? c) (d/realized? d))))
         (is (= 12 @(s/take! s)))
-        (is (realized? d))
+        (is (d/realized? d))
         (is (= true @d))
         (is (= 1 @(s/take! s)))))))
 


### PR DESCRIPTION
Manifold occasionally used `clojure.core/realized?` instead of its `manifold.deferred/realized?`. For the most part, this isn't a problem, since all the deferred classes implement IPending, but I'm experimenting with CompletableFuture support, and it *would* be a problem for that, since IPending is an interface which can't be extended to Java classes, and I can't change it to a protocol since it's part of core clojure.