### PR TITLE
Remove support for java 7 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,27 +121,9 @@ Manifold can use any transducer, which are applied via `transform`.  It also pro
 
 A Clojurescript implementation of Manifold can be found here: [dm3/manifold-cljs](https://github.com/dm3/manifold-cljs).
 
-### Older Java support
-
-Manifold includes support for a few classes introduced in Java 8:
-`java.util.concurrent.CompletableFuture` and `java.util.stream.BaseStream`.
-Support for Java 8+ is detected automatically at compile time; if you are
-AOT compiling Manifold on Java 8 or newer, but will be running the compiled
-jar with a Java 7 or older JRE, you will need to disable them, by
-setting the JVM option `"manifold.disable-jvm8-primitives"`, either at the
-command line with
-
-    -Dmanifold.disable-jvm8-primitives=true
-
-or by adding
-
-    :jvm-opts ["-Dmanifold.disable-jvm8-primitives=true"]
-
-to your application's project.clj.
-
 
 ### License
 
-Copyright © 2014-2021 Zach Tellman
+Copyright © 2014-2022 Zach Tellman
 
 Distributed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ Manifold provides two core abstractions: **deferreds**, which represent a single
 
 A detailed discussion of Manifold's rationale can be found [here](doc/rationale.md).  Full documentation can be found [here](https://cljdoc.org/d/manifold/manifold).
 
-
+Leiningen:
 ```clojure
 [manifold "0.2.4"]
+```
+
+deps.edn:
+```clojure
+manifold/manifold {:mvn/version "0.2.4"}
 ```
 
 ### Deferreds

--- a/project.clj
+++ b/project.clj
@@ -25,4 +25,13 @@
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Xmx2g"
                        "-XX:NewSize=1g"]
-  :javac-options ["-target" "1.8" "-source" "1.8"])
+  :javac-options ["-target" "1.8" "-source" "1.8"]
+
+  :pom-addition ([:organization
+                  [:name "CLJ Commons"]
+                  [:url "http://clj-commons.org/"]]
+                 [:developers [:developer
+                               [:id "kingmob"]
+                               [:name "Matthew Davidson"]
+                               [:url "http://modulolotus.net"]
+                               [:email "matthew@modulolotus.net"]]]))

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :url "https://github.com/clj-commons/manifold"
-  :scm {:name "git" :url "https://github.com/KingMob/manifold"}
+  :scm {:name "git" :url "https://github.com/clj-commons/manifold"}
   :dependencies [[org.clojure/clojure "1.11.0" :scope "provided"]
                  [org.clojure/tools.logging "1.1.0" :exclusions [org.clojure/clojure]]
                  [io.aleph/dirigiste "1.0.0"]
@@ -24,4 +24,5 @@
   :jvm-opts ^:replace ["-server"
                        "-XX:-OmitStackTraceInFastThrow"
                        "-Xmx2g"
-                       "-XX:NewSize=1g"])
+                       "-XX:NewSize=1g"]
+  :javac-options ["-target" "1.8" "-source" "1.8"])

--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -22,13 +22,12 @@
      Future
      TimeoutException
      TimeUnit
-     ConcurrentHashMap
      CountDownLatch
-     Executor]
+     Executor
+     CompletableFuture]
     [java.util.concurrent.locks
      Lock]
     [java.util.concurrent.atomic
-     AtomicBoolean
      AtomicInteger
      AtomicLong]
     [clojure.lang
@@ -1259,20 +1258,18 @@
               (success! d msg))))
           d))))
 
-(utils/when-class java.util.concurrent.CompletableFuture
+(extend-protocol Deferrable
 
-  (extend-protocol Deferrable
-
-    java.util.concurrent.CompletableFuture
-    (to-deferred [f]
-      (let [d (deferred)]
-        (.handle ^java.util.concurrent.CompletableFuture f
-                 (reify java.util.function.BiFunction
-                   (apply [_ val err]
-                     (if (nil? err)
-                       (success! d val)
-                       (error! d err)))))
-        d))))
+  CompletableFuture
+  (to-deferred [f]
+    (let [d (deferred)]
+      (.handle ^CompletableFuture f
+               (reify java.util.function.BiFunction
+                 (apply [_ val err]
+                   (if (nil? err)
+                     (success! d val)
+                     (error! d err)))))
+      d)))
 
 ;;;
 

--- a/src/manifold/stream/iterator.clj
+++ b/src/manifold/stream/iterator.clj
@@ -12,7 +12,8 @@
     [java.util
      Iterator]
     [java.util.concurrent.atomic
-     AtomicReference]))
+     AtomicReference]
+    (java.util.stream BaseStream)))
 
 (s/def-source IteratorSource
   [^Iterator iterator
@@ -63,19 +64,14 @@
           d)))))
 
 (extend-protocol s/Sourceable
-
-  java.util.Iterator
+  Iterator
   (to-source [iterator]
     (->IteratorSource
       iterator
+      (AtomicReference. (d/success-deferred true))))
+
+  BaseStream
+  (to-source [stream]
+    (->IteratorSource
+      (.iterator ^BaseStream stream)
       (AtomicReference. (d/success-deferred true)))))
-
-(utils/when-class java.util.stream.BaseStream
-
-  (extend-protocol s/Sourceable
-
-    java.util.stream.BaseStream
-    (to-source [stream]
-      (->IteratorSource
-        (.iterator ^java.util.stream.BaseStream stream)
-        (AtomicReference. (d/success-deferred true))))))

--- a/src/manifold/utils.clj
+++ b/src/manifold/utils.clj
@@ -121,14 +121,11 @@
     `(do ~@body)))
 
 (defmacro when-class [class & body]
-  (let [disable-property (System/getProperty "manifold.disable-jvm8-primitives")
-        disabled?        (and disable-property (not= disable-property "false"))]
-    (when (and (not disabled?)
-               (try
-                 (Class/forName (name class))
-                 (catch Throwable e
-                   )))
-      `(do ~@body))))
+  (when (try
+          (Class/forName (name class))
+          (catch Exception _
+            false))
+    `(do ~@body)))
 
 ;;;
 

--- a/test/manifold/deferred_test.clj
+++ b/test/manifold/deferred_test.clj
@@ -6,7 +6,8 @@
     [clojure.test :refer :all]
     [manifold.test-utils :refer :all]
     [manifold.deferred :as d]
-    [manifold.executor :as ex]))
+    [manifold.executor :as ex])
+  (:import (java.util.concurrent CompletableFuture)))
 
 (defmacro future' [& body]
   `(d/future
@@ -271,14 +272,13 @@
 (deftest test-coercion
   (is (= 1 (-> 1 clojure.core/future d/->deferred deref)))
 
-  (utils/when-class java.util.concurrent.CompletableFuture
-    (let [f (java.util.concurrent.CompletableFuture.)]
-      (.obtrudeValue f 1)
-      (is (= 1 (-> f d/->deferred deref))))
+  (let [f (CompletableFuture.)]
+    (.obtrudeValue f 1)
+    (is (= 1 (-> f d/->deferred deref))))
 
-    (let [f (java.util.concurrent.CompletableFuture.)]
-      (.obtrudeException f (Exception.))
-      (is (thrown? Exception (-> f d/->deferred deref))))))
+  (let [f (CompletableFuture.)]
+    (.obtrudeException f (Exception.))
+    (is (thrown? Exception (-> f d/->deferred deref)))))
 
 (deftest test-finally
   (let [target-d (d/deferred)

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -94,8 +94,7 @@
 (deftest test-sources
   (doseq [f [#(java.util.ArrayList. ^java.util.List %)
              #(.iterator ^java.util.List %)
-             (utils/when-class java.util.stream.BasicStream
-               (run-source-test #(-> % java.util.ArrayList. .stream)))]]
+             #(-> % (java.util.ArrayList.) .stream)]]
     (when f
       (= (range 100) (-> (range 100) f s/->source s/stream->seq)))
     (when f


### PR DESCRIPTION
Removes the use of `when-class` on classes/interfaces introduced in Java 8. Also fixes a bug in BaseStream test, and adds some minor docs and POM info.