### PR TITLE
Reduce levels of go-off nesting in `go-off-nests` test

### DIFF
--- a/test/manifold/go_off_test.clj
+++ b/test/manifold/go_off_test.clj
@@ -57,7 +57,7 @@
 (deftest go-off-nests
   (testing "return deferred will always result in a a realizable value, not another deferred"
     (is (= [23 42] @(go-off (let [let* 1 a 23] (go-off (let* [b 42] [a b]))))))
-    (is (= 5 @(go-off (go-off (go-off (go-off (go-off (go-off (go-off 5))))))))))
+    (is (= 5 @(go-off (go-off (go-off (go-off (go-off 5))))))))
   (testing "Parking unwraps nested deferreds"
     (is (= 5 @(go-off (<!? (go-off (go-off (go-off 5)))))))))
 


### PR DESCRIPTION
Adding a `let` with a single binding wrapping the test body results in `ClassFormatError: Too many arguments in method signature in class file`.

The state machine-generating code results in a method with over 256 parameters, which is a violation of the Java class spec.

While it technically works at the moment, this is fragile, so I'm reducing the nesting a couple levels.