### PR TITLE
Add clj-kondo config for loop and let-flow

### DIFF
--- a/resources/clj-kondo.exports/manifold/manifold/config.edn
+++ b/resources/clj-kondo.exports/manifold/manifold/config.edn
@@ -1,0 +1,8 @@
+{
+ ;; aliasing loop to let is enought to get
+ ;; great linting.
+
+
+ :lint-as {manifold.deferred/let-flow clojure.core/let
+           manifold.deferred/loop clojure.core/let}
+ }

--- a/resources/clj-kondo.exports/manifold/manifold/config.edn
+++ b/resources/clj-kondo.exports/manifold/manifold/config.edn
@@ -4,5 +4,6 @@
 
 
  :lint-as {manifold.deferred/let-flow clojure.core/let
+           manifold.deferred/let-flow' clojure.core/let
            manifold.deferred/loop clojure.core/let}
  }


### PR DESCRIPTION
As mentioned in issue #214, it would be very nice to have clj-kondo support for some macros. It turns out this is fairly simple to do for let-flow and loop as their API is similar to clojure.core/let. 