### PR TITLE
Improve docstring of mapcat

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -740,7 +740,10 @@
                                      (d/recur r))))))))))))))
 
 (defn mapcat
-  "Equivalent to Clojure's `mapcat`, but for streams instead of sequences."
+  "Equivalent to Clojure's `mapcat`, but for streams instead of sequences.
+  
+  Note that just like `clojure.core/mapcat`, the provided function `f`
+  must return a collection and not a stream."
   ([f s]
    (let [s' (stream)]
      (connect-via s


### PR DESCRIPTION
To deal with issue #179, adds a note that the argument function of `mapcat` must not return a stream, but a collection instead.
