### PR TITLE
Fix close! misleading doc

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -196,7 +196,11 @@
   `(.isSynchronous ~(with-meta x {:tag "manifold.stream.core.IEventStream"})))
 
 (definline close!
-  "Closes a source or sink, so that it can't emit or accept any more messages."
+  "Closes a sink, so that it can't emit any more messages.
+
+  Note that 'take's on associated sources will still work until
+  the sink is exhausted."
+
   [sink]
   `(.close ~(with-meta sink {:tag "manifold.stream.core.IEventStream"})))
 

--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -196,10 +196,9 @@
   `(.isSynchronous ~(with-meta x {:tag "manifold.stream.core.IEventStream"})))
 
 (definline close!
-  "Closes a sink, so that it can't emit any more messages.
+  "Closes a sink, so you can't `put!` any more messages onto it.
 
-  Note that 'take's on associated sources will still work until
-  the sink is exhausted."
+   Note that if it's also a source, `take!`s will still work until the source is drained."
 
   [sink]
   `(.close ~(with-meta sink {:tag "manifold.stream.core.IEventStream"})))


### PR DESCRIPTION
~~This changes help a bit with tackling issue #176 by making so that closing a BlockingQueueSource prevents further takes.~~

The documentation for close! is a bit misleading in regards to sources.