### PR TITLE
Minor window function improvements

### DIFF
--- a/src/manifold/stream.clj
+++ b/src/manifold/stream.clj
@@ -1127,11 +1127,11 @@
      (connect-via
        source
        (fn [val]
-         (d/let-flow [put-result (try-put! sink val 0 :timeout)]
+         (d/let-flow [put-result (try-put! sink val 0 ::timeout)]
            (case put-result
              true     true
              false    false
-             :timeout true)))
+             ::timeout true)))
        sink
        {:upstream?   true
         :downstream? true})
@@ -1156,12 +1156,12 @@
        (fn [val]
          (d/loop []
            (d/chain
-             (try-put! sink val 0 :timeout)
+             (try-put! sink val 0 ::timeout)
              (fn [put-result]
                (case put-result
                  true     true
                  false    false
-                 :timeout (d/chain (take! sink)
+                 ::timeout (d/chain (take! sink)
                                    (fn [_] (d/recur))))))))
        sink
        {:upstream?   true

--- a/test/manifold/stream_test.clj
+++ b/test/manifold/stream_test.clj
@@ -468,15 +468,15 @@
 (deftest test-window-streams
   (testing "dropping-stream"
     (let [s (s/->source (range 11))
-          sliding-s (s/dropping-stream 10 s)]
+          dropping-s (s/dropping-stream 10 s)]
       (is (= (range 10)
-             (s/stream->seq sliding-s)))))
+             (s/stream->seq dropping-s)))))
 
   (testing "sliding-stream"
     (let [s (s/->source (range 11))
           sliding-s (s/sliding-stream 10 s)]
       (is (= (range 1 11)
-             (s/stream->seq sliding-s)))))  )
+             (s/stream->seq sliding-s))))))
 
 ;;;
 


### PR DESCRIPTION
This fixes some readability issues with the window function tests, and changes the window functions to use namespaced `:timeout` symbols.