### PR TITLE
Add clj-kondo support for internal macros

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -9,7 +9,9 @@
  :hooks {:analyze-call
          {manifold.stream.core/def-source manifold.hooks/def-sink-or-source
           manifold.stream.core/def-sink manifold.hooks/def-sink-or-source
-          manifold.stream.core/def-sink+source manifold.hooks/def-sink-or-source}}
+          manifold.stream.core/def-sink+source manifold.hooks/def-sink-or-source
+          manifold.deferred/both manifold.hooks/both
+          manifold.deferred/success-error-unrealized manifold.hooks/success-error-unrealized}}
 
 
 :config-in-call {manifold.stream.core/def-sink+source

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,10 +1,7 @@
 {:lint-as {manifold.utils/definterface+ clojure.core/definterface
            manifold.utils/deftype+ clojure.core/deftype
            manifold.utils/defrecord+ clojure.core/defrecord
-           manifold.utils/defprotocol+ clojure.core/defprotocol
-           manifold.stream.core/def-source clojure.core/deftype
-           manifold.stream.core/def-sink clojure.core/deftype
-           manifold.stream.core/def-sink+source clojure.core/deftype}
+           manifold.utils/defprotocol+ clojure.core/defprotocol}
 
  :hooks {:analyze-call
          {manifold.stream.core/def-source manifold.hooks/def-sink-or-source

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,24 @@
+{:lint-as {manifold.utils/definterface+ clojure.core/definterface
+           manifold.utils/deftype+ clojure.core/deftype
+           manifold.utils/defrecord+ clojure.core/defrecord
+           manifold.utils/defprotocol+ clojure.core/defprotocol
+           manifold.stream.core/def-source clojure.core/deftype
+           manifold.stream.core/def-sink clojure.core/deftype
+           manifold.stream.core/def-sink+source clojure.core/deftype}
+
+ :hooks {:analyze-call
+         {manifold.stream.core/def-source manifold.hooks/def-sink-or-source
+          manifold.stream.core/def-sink manifold.hooks/def-sink-or-source
+          manifold.stream.core/def-sink+source manifold.hooks/def-sink-or-source}}
+
+
+:config-in-call {manifold.stream.core/def-sink+source
+                 {:linters {:redefined-var {:level :off}}}
+
+                 manifold.stream.core/def-sink
+                 {:linters {:redefined-var {:level :off}}}
+
+                 manifold.stream.core/def-source
+                 {:linters {:redefined-var {:level :off}}}}
+
+ :config-paths ["../resources/clj-kondo.exports/manifold/manifold/"]}

--- a/.clj-kondo/manifold/hooks.clj
+++ b/.clj-kondo/manifold/hooks.clj
@@ -1,0 +1,30 @@
+(ns manifold.hooks
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn- cons-vector-node
+  [node parent]
+  (api/vector-node (cons node (:children parent))))
+
+(defn def-sink-or-source [call]
+  (let [[name bindings & body] (-> call :node :children rest)
+        extended-bindings
+        (cons-vector-node (api/token-node 'lock) bindings)]
+
+    {:node
+     (api/list-node
+      (list
+       (api/token-node 'do)
+
+       (api/list-node
+        (list*
+         (api/token-node 'deftype)
+         name
+         extended-bindings
+         body))
+
+       (api/list-node
+        (list
+         (api/token-node 'defn)
+         (api/token-node (symbol (str "->" (:string-value name))))
+         bindings
+         ))))}))


### PR DESCRIPTION
This adds `clj-kondo` support for the problematic private macros in manifold. The `def-type+` family was
just aliased to their `clojure.core` counterparts as it is a group of simple wrappers.

The `def-source` family could be linted as `deftype`, but that would generate 
issues with the implied `lock` attribute. Instead, the approach taken was to provide a hook
that expands calls to a `deftype` declaration containing the `lock` attribute/parameter.
Additionally, it provides a `->` constructor function that accepts the original parameters without the `lock`,
just like the original `def-source` macro family does.

However, this causes a var redefinition warning, which is disabled for those macros since their real expansion really contains a var redefinition.

Support was also added for the `both` and `success-error-unrealized` macros in `manifold.deferred`.