### PR TITLE
Upgrade to core.async 1.6.673

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,3 +40,4 @@ jobs:
 
       # run tests!
       - run: lein do clean, test
+      - run: lein with-profile +older-core-async do clean, test manifold.go-off-test

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,10 @@
                  [riddley "0.2.0"]
                  [org.clojure/core.async "1.6.673" :scope "provided"]
                  [potemkin "0.4.6"]]
-  :profiles {:dev {:dependencies [[criterium "0.4.6"]]}}
+  :profiles {:dev {:dependencies [[criterium "0.4.6"]]}
+             ;; core.async moved around some internal functions go-off relies on; this profile
+             ;; helps test that go-off still works both with the new namespaces and the old
+             :older-core-async {:dependencies [[org.clojure/core.async "1.5.648" :scope "provided"]]}}
   :test-selectors {:default #(not
                                (some #{:benchmark :stress}
                                  (cons (:tag %) (keys %))))

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/tools.logging "1.2.4" :exclusions [org.clojure/clojure]]
                  [org.clj-commons/dirigiste "1.0.3"]
                  [riddley "0.2.0"]
-                 [org.clojure/core.async "1.5.648" :scope "provided"]
+                 [org.clojure/core.async "1.6.673" :scope "provided"]
                  [potemkin "0.4.6"]]
   :profiles {:dev {:dependencies [[criterium "0.4.6"]]}}
   :test-selectors {:default #(not

--- a/src/manifold/go_off.clj
+++ b/src/manifold/go_off.clj
@@ -6,10 +6,15 @@
              [executor :as ex]
              [deferred :as d]]
             [clojure.core.async.impl
-             [runtime :as async-runtime]
              [ioc-macros :as ioc]]
             [manifold.stream :as s])
   (:import (manifold.stream.core IEventSource)))
+
+;; a number of functions from `ioc-macros` moved to `runtime` in org.clojure/core.async "1.6.673"
+;; since they were just moved without functionality changes, continue to support both via dynamic import
+(if (find-ns 'clojure.core.async.impl.runtime)
+  (require '[clojure.core.async.impl.runtime :as async-runtime])
+  (require '[clojure.core.async.impl.ioc-macros :as async-runtime]))
 
 (defn ^:no-doc return-deferred [state value]
   (let [d (async-runtime/aget-object state async-runtime/USER-START-IDX)]


### PR DESCRIPTION
Some of the functions that we were relying on to hijack the go state machine compilation changed namespaces. This updates the code to reference where they now live.

Addresses https://github.com/clj-commons/manifold/issues/229