### PR TITLE
Fix print-method bug

### DIFF
--- a/src/manifold/deferred.clj
+++ b/src/manifold/deferred.clj
@@ -1521,6 +1521,7 @@
             " >>")))
 
 (prefer-method print-method IDeferred IDeref)
+(prefer-method print-method IDeferred CompletionStage)
 
 
 


### PR DESCRIPTION
Promesa adds CompletionStage as a dispatch value, which causes hierarchy conflicts when attempting to `pr` a deferred.

E.g.:

> java.lang.IllegalArgumentException: Multiple methods in multimethod 'print-method' match dispatch value: class manifold.deferred.Deferred -> interface java.util.concurrent.CompletionStage and interface manifold.deferred.IDeferred, and neither is preferred
